### PR TITLE
hotfix(footer): fix - attempt 2

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -51,6 +51,7 @@ $primary-budgeting-kid-background-color: hsl(270, 95%, 98%);
   border-top: 1px solid hsl(0, 0%, 90%);
   position: sticky;
   bottom: 0;
+  overflow: hidden;
   padding: 10px;
   background-color: hsl(0, 0%, 96%);
 }


### PR DESCRIPTION
! In interaction `overflow: hidden;` with the hiding/showing of the address line can be a side effect. In this case, need to revert.