### PR TITLE
fix(avatar): load the default image

### DIFF
--- a/app/views/devise/registrations/edit.html.slim
+++ b/app/views/devise/registrations/edit.html.slim
@@ -5,7 +5,7 @@
       .columns.is-mobile
         .column.is-one-third
           .field
-            img src=avatar_for(current_user) class="rounded-avatar" id='account-image' alt='avatar'
+            img src=asset_path(avatar_for(current_user)) class="rounded-avatar" id='account-image'
         .column
           .file#file-input.is-light.is-pulled-right
             label.file-label.is-light

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -84,7 +84,7 @@
                 <% if user_signed_in? %>
                   <div class="navbar-item has-dropdown is-hoverable">
                     <a class="button is-rounded for-desktop p-0 m-0" style="width: 72px; height: 72px;" >
-                      <img src=<%=avatar_for(current_user)%> class="rounded-avatar small">
+                      <img src=<%=asset_path(avatar_for(current_user))%> class="rounded-avatar small">
                     </a>
                     <div class="navbar-dropdown is-right is-boxed">
                       <%= link_to edit_user_registration_path, class: "navbar-item"  do %>
@@ -121,11 +121,11 @@
         </div>
       </nav>
 
-      <section class="section is-fullheight p-2 mt-4">
+      <section class="section is-fullheight py-2 mt-4">
         <%= yield %>
       </section>
 
-      <footer class="footer is-flex-align-items-flex-end mt-auto">
+      <footer class="footer is-flex-align-items-flex-end mt-auto pb-6">
         <p>© <%= Time.current.year %> BudgetingKid</p>
         <p>Designed with love by <%= link_to("WideFix", "https://widefix.com/")%></p>
         <%= link_to("Privacy Policy", policy_path) %>


### PR DESCRIPTION
1. Default avatar images aren't loaded.
2. Borders of the`yield` section have changed to the right content location, including the background image on the login and signup pages.