### PR TITLE
fix(wizards): leave the single backgrownd picture

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,10 @@ class ApplicationController < ActionController::Base
 
   private
 
+  helper_method def show_application_background?
+    user_signed_in? && controller_name != 'wizards'
+  end
+
   helper_method memoize def account
     Account.visible_for(current_user).unarchived.find(ps.fetch(:account_id))
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -63,7 +63,7 @@
     <% end %>
   </head>
 
-  <body class=<%= user_signed_in? ? 'with-background' : ''%>>
+  <body class=<%= show_application_background? ? 'with-background' : ''%>>
     <div class="container hero is-fullheight">
       <nav class="navbar is-spaced has-shadow <%= user_signed_in? ? 'is-navbar-budgeting-kid-color' : ''%>"
            role="navigation"


### PR DESCRIPTION
There was 2 background pictures on the wizard pages:
![image](https://github.com/widefix/pocketmoney/assets/81028629/1d1b23b4-ca66-458e-90b2-d0043b0c168b)
