### PR TITLE
fix(archive account buttons): replace and rename buttons

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -235,6 +235,11 @@ $primary-budgeting-kid-light-gray-color: hsla(0, 0%, 68%, 1);
   border: none;
 }
 
+.button.is-white-budgeting-kid-color {
+  color: $primary-budgeting-kid-color !important;
+  border: none;
+}
+
 .is-bordered {
   border: 2px solid $primary-budgeting-kid-color !important ;
 }
@@ -277,6 +282,16 @@ button.is-minus-color {
   border-radius: 6px;
   border: 2px solid hsl(8, 82%, 41%);
   color: hsl(8, 82%, 41%);
+}
+
+.button.is-budgeting-kid-danger {
+  border-radius: 6px;
+  border: 2px solid hsl(8, 82%, 41%);
+  color: hsl(8, 82%, 41%);
+}
+
+.button.is-budgeting-kid-danger:hover {
+  background-color: hsla(8, 82%, 41%, 0.1);
 }
 
 button.is-plus-color:hover {

--- a/app/views/accounts/edit.html.slim
+++ b/app/views/accounts/edit.html.slim
@@ -53,15 +53,48 @@
           .notification.is-light.mt-3
             | If checked, all users with access to your kid's account, including you, will get email notifications 
             | about balance changes.
-      buttons.is-flex.is-justify-content-flex-end
-        = link_to account_path(account), class: 'button is-light mr-2' do
-          span.file-icon
-            i.fa.fa-chevron-left
-          | Back
-        = button_to account_path, class: 'button is-primary' do
-          span.file-icon
-            i.fa.fa-hdd-o
-          | Save
+      buttons.is-flex.is-justify-content-space-between.for-desktop
+        - if current_user.parent?
+          - if current_user.owner?(account)
+            = link_to archive_account_path(account), data: { confirm: 'Archive this account?' }, class: 'button is-budgeting-kid-danger', style: "width: 180px" do
+              span.icon
+                i.fa.fa-archive
+              | &nbsp; Archive Account
+          - else
+            = link_to terminate_shared_account_path(account), method: :patch, data: {confirm: 'Would you like to decline this share?'}, class: 'button is-budgeting-kid-danger' do
+              span.icon
+                i.fa.fa-sign-out
+              | &nbsp; Decline Share
+        div
+          = link_to account_path(account), class: 'button is-white is-bordered mr-2' do
+            span.file-icon
+              i.fa.fa-chevron-left
+            | Back
+          = button_to account_path, class: 'button is-primary' do
+            span.file-icon
+              i.fa.fa-hdd-o
+            | Save
+      buttons.is-flex.is-flex-direction-column.for-mobile
+        - if current_user.parent?
+          - if current_user.owner?(account)
+            = link_to archive_account_path(account), data: { confirm: 'Archive this account?' }, class: 'button is-budgeting-kid-danger mb-4', style: "width: 180px" do
+              span.icon
+                i.fa.fa-archive
+              | &nbsp; Archive Account
+          - else
+            = link_to terminate_shared_account_path(account), method: :patch, data: {confirm: 'Would you like to decline this share?'}, class: 'button is-budgeting-kid-danger mb-4' do
+              span.icon
+                i.fa.fa-sign-out
+              | &nbsp; Decline Share
+        .is-flex.is-justify-content-flex-end
+          = link_to account_path(account), class: 'button is-white is-bordered mr-2' do
+            span.file-icon
+              i.fa.fa-chevron-left
+            | Back
+          = button_to account_path, class: 'button is-primary' do
+            span.file-icon
+              i.fa.fa-hdd-o
+            | Save
 
 javascript:
   document.addEventListener('turbolinks:load', function () {

--- a/app/views/accounts/show.html.slim
+++ b/app/views/accounts/show.html.slim
@@ -1,7 +1,7 @@
 #topup-utc-time data-utc-time= topup_utc_time
 .columns
   / desktop
-  .column.for-desktop.is-two-fifths.box.m-2(style="#{"background-image: url('#{url_for(account.background)}');" if account.background.attached?}" class="#{'account-has-bg' if account.background.attached?}")
+  .column.for-desktop.box.m-2(style="#{"background-image: url('#{url_for(account.background)}');" if account.background.attached?}" class="#{'account-has-bg' if account.background.attached?}")
     .p-4
       - if !current_user.owner?(account) && current_user.parent?
         .columns
@@ -15,7 +15,7 @@
           .title.is-black-budgeting-kid-color(class="#{'bg-around-text' if account.background.attached?}")
             = account.name
   / mobile
-  .column.for-mobile.is-two-fifths.box(style="#{"background-image: url('#{url_for(account.background)}');" if account.background.attached?}" class="#{'account-has-bg' if account.background.attached?}")
+  .column.for-mobile.box(style="#{"background-image: url('#{url_for(account.background)}');" if account.background.attached?}" class="#{'account-has-bg' if account.background.attached?}")
     .p-4
       - if !current_user.owner?(account) && current_user.parent?
         .columns
@@ -40,17 +40,6 @@
         figure.image.is-16x16.is-budgeting-kid-light-color
           = image_tag('edit.svg')
         | &nbsp; Edit Account
-      - if current_user.parent?
-        - if current_user.owner?(account)
-          = link_to archive_account_path(account), data: { confirm: 'Archive this account?' }, class: 'button is-white-budgeting-kid-color is-bordered py-5 mx-4', style: "width: 180px" do
-            span.icon
-              i.fa.fa-archive
-            | &nbsp; Archive Account
-        - else
-          = link_to terminate_shared_account_path(account), method: :patch, data: {confirm: 'Would you like to terminate this account?'}, class: 'button is-white-budgeting-kid-color is-bordered py-5 mx-4' do
-            span.icon
-              i.fa.fa-sign-out
-            | &nbsp; Terminate Account
   / mobile
   .column.for-mobile.box.mb-5.is-flex.is-justify-content-center.is-align-items-center
     .buttons
@@ -61,15 +50,6 @@
       = link_to edit_account_path(account), class: 'button is-white-budgeting-kid-color is-bordered mx-2', style: "width: 80px; " do
         figure.image.is-16x16.is-budgeting-kid-light-color
           = image_tag('edit.svg')
-      - if current_user.parent?
-        - if current_user.owner?(account)
-          = link_to archive_account_path(account), data: { confirm: 'Archive this account?' }, class: 'button is-white-budgeting-kid-color is-bordered mx-2', style: "width: 80px" do
-            span.icon
-              i.fa.fa-archive
-        - else
-          = link_to terminate_shared_account_path(account), method: :patch, data: {confirm: 'Would you like to terminate this account?'}, class: 'button is-white-budgeting-kid-color is-bordered mx-2', style: "width: 80px" do
-            span.icon
-              i.fa.fa-sign-out
 / desktop
 .box.for-desktop.is-flex.is-justify-content-center.is-align-items-center
   div

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -18,8 +18,6 @@ RSpec.feature 'Account', type: :feature do
     expect(page).to have_http_status(:success)
     expect(page).to have_link('Edit Account', href: edit_account_path(account))
     expect(page).to have_link('Share Account', href: account_shares_path(account))
-    expect(page).to have_link('Archive Account', href: archive_account_path(account))
-      .or(have_link('Terminate Account', href: terminate_shared_account_path(account)))
     expect(page).to have_content(account.name)
     expect(page).to have_content(account.balance)
     expect(page).to have_button('Increase')


### PR DESCRIPTION
![Screenshot from 2023-12-05 14-47-33](https://github.com/widefix/pocketmoney/assets/62177364/7bc8c2a3-8049-4119-8ca5-ee15536a2075)
![Screenshot from 2023-12-05 14-47-10](https://github.com/widefix/pocketmoney/assets/62177364/32c4e448-d576-4c4e-89c6-adc0f094bad8)
![Screenshot from 2023-12-05 14-46-52](https://github.com/widefix/pocketmoney/assets/62177364/279f9b0b-0b53-4a9e-8dbe-51a3ff39b539)
![Screenshot from 2023-12-05 14-46-23](https://github.com/widefix/pocketmoney/assets/62177364/dd217604-29ee-4e5a-bff1-5fd300287bf4)
